### PR TITLE
Avoid already crawled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# cookies files
+cookies.txt

--- a/config.json
+++ b/config.json
@@ -15,5 +15,6 @@
     "https://www.linkedin.com/in/here/",
     "https://www.linkedin.com/in/profiles/",
     "https://www.linkedin.com/in/to-start-the-crawler/"
-  ]
+  ],
+  "avoidAlreadyCrawled": true
 }

--- a/config.json
+++ b/config.json
@@ -16,5 +16,5 @@
     "https://www.linkedin.com/in/profiles/",
     "https://www.linkedin.com/in/to-start-the-crawler/"
   ],
-  "avoidAlreadyCrawled": true
+  "avoidAlreadyCrawled": false
 }

--- a/src/crawler.js
+++ b/src/crawler.js
@@ -24,8 +24,8 @@ module.exports = async (profileScraper, rootProfiles, injection) => new Promise(
 
     scrapProfile(profileScraper, profileUrl)
       .then((relatedProfiles) => {
-          additionalProfiles = difference(new Set(relatedProfiles), alreadyCrawledProfiles)
-	  logger.info(additionalProfiles)
+          additionalProfiles = difference(new Set(relatedProfiles),
+					  alreadyCrawledProfiles)
           nextProfilesToCrawl = union(nextProfilesToCrawl,
                                       additionalProfiles)
 
@@ -44,7 +44,8 @@ module.exports = async (profileScraper, rootProfiles, injection) => new Promise(
     } else if (currentProfilesToCrawl.length === 0) {
       logger.info(`a depth of crawling was finished, starting a new depth with ${nextProfilesToCrawl.size} profile(s)`)
 	currentProfilesToCrawl = Array.from(nextProfilesToCrawl)
-	alreadyCrawledProfiles = union(alreadyCrawledProfiles, new Set(currentProfilesToCrawl))
+	alreadyCrawledProfiles = union(alreadyCrawledProfiles,
+				       nextProfilesToCrawl)
       nextProfilesToCrawl = new Set()
     } else if (parallelCrawlers < config.maxConcurrentCrawlers) {
       const profileUrl = currentProfilesToCrawl.shift()

--- a/src/crawler.js
+++ b/src/crawler.js
@@ -25,7 +25,7 @@ module.exports = async (profileScraper, rootProfiles, injection) => new Promise(
     scrapProfile(profileScraper, profileUrl)
       .then((relatedProfiles) => {
           additionalProfiles = difference(new Set(relatedProfiles),
-					  alreadyCrawledProfiles)
+                                          alreadyCrawledProfiles)
           nextProfilesToCrawl = union(nextProfilesToCrawl,
                                       additionalProfiles)
 
@@ -43,9 +43,9 @@ module.exports = async (profileScraper, rootProfiles, injection) => new Promise(
       logger.info('there is no profiles to crawl right now...')
     } else if (currentProfilesToCrawl.length === 0) {
       logger.info(`a depth of crawling was finished, starting a new depth with ${nextProfilesToCrawl.size} profile(s)`)
-	currentProfilesToCrawl = Array.from(nextProfilesToCrawl)
-	alreadyCrawledProfiles = union(alreadyCrawledProfiles,
-				       nextProfilesToCrawl)
+        currentProfilesToCrawl = Array.from(nextProfilesToCrawl)
+        alreadyCrawledProfiles = union(alreadyCrawledProfiles,
+                                       nextProfilesToCrawl)
       nextProfilesToCrawl = new Set()
     } else if (parallelCrawlers < config.maxConcurrentCrawlers) {
       const profileUrl = currentProfilesToCrawl.shift()

--- a/src/crawler.js
+++ b/src/crawler.js
@@ -43,9 +43,11 @@ module.exports = async (profileScraper, rootProfiles, injection) => new Promise(
       logger.info('there is no profiles to crawl right now...')
     } else if (currentProfilesToCrawl.length === 0) {
       logger.info(`a depth of crawling was finished, starting a new depth with ${nextProfilesToCrawl.size} profile(s)`)
-        currentProfilesToCrawl = Array.from(nextProfilesToCrawl)
+      currentProfilesToCrawl = Array.from(nextProfilesToCrawl)
+      if (config.avoidAlreadyCrawled) {
         alreadyCrawledProfiles = union(alreadyCrawledProfiles,
                                        nextProfilesToCrawl)
+      }
       nextProfilesToCrawl = new Set()
     } else if (parallelCrawlers < config.maxConcurrentCrawlers) {
       const profileUrl = currentProfilesToCrawl.shift()


### PR DESCRIPTION
This is a fix to #21. As @anasdox suggested, it's a good start to keep profiles in memory and not re-scrape profiles that were scraped in the current run.

I used `Set`s to guarantee that `relatedProfiles` doesn't have any repeats, and save the already scraped profiles which are checked before adding to `nextProfilesToCrawl`

It would be nice to avoid scraping profiles that are already in the directory, but it seems reasonable to start with this. It will at least avoid infinite loops. 

The long term solution where there is some kind of long-term memory would be nice, but I think that should probably be a separate enhancement.