### PR TITLE
Inter profile waits

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,5 +15,6 @@
     "https://www.linkedin.com/in/here/",
     "https://www.linkedin.com/in/profiles/",
     "https://www.linkedin.com/in/to-start-the-crawler/"
-  ]
+  ],
+  "interProfileWaitTime": 1000
 }

--- a/src/crawler.js
+++ b/src/crawler.js
@@ -4,7 +4,6 @@ const dependencies = {
   scrapProfile: require('./scrapProfile')
 }
 
-const WORKER_INTERVAL_MS = 1000
 
 module.exports = async (profileScraper, rootProfiles, injection) => new Promise((resolve) => {
   const {
@@ -12,6 +11,7 @@ module.exports = async (profileScraper, rootProfiles, injection) => new Promise(
     scrapProfile
   } = Object.assign({}, dependencies, injection)
 
+  const WORKER_INTERVAL_MS = config.workerIntervalWaitTime
   let currentProfilesToCrawl = rootProfiles
   let nextProfilesToCrawl = []
 


### PR DESCRIPTION
This just adds a line to the `config.json` that allows you to control the wait between profile workers being spawned, a fix for feature request #44.